### PR TITLE
feat: add dark/light mode toggle (closes #1)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import Dashboard from './pages/Dashboard';
+import { ThemeProvider } from './context/ThemeContext';
 import './styles/globals.css';
 import './styles/animations.css';
 
@@ -42,14 +43,16 @@ function App() {
   }, []);
 
   return (
-    <Router>
-      <div className="app-main">
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-        </Routes>
-      </div>
-    </Router>
+    <ThemeProvider>
+      <Router>
+        <div className="app-main">
+          <Routes>
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+          </Routes>
+        </div>
+      </Router>
+    </ThemeProvider>
   );
 }
 

--- a/client/src/components/Landing/Hero/HeroSection.jsx
+++ b/client/src/components/Landing/Hero/HeroSection.jsx
@@ -9,6 +9,7 @@ import { Stars } from '@react-three/drei';
 import { useNavigate } from 'react-router-dom';
 import ParticleNetwork from './ParticleNetwork';
 import WireframeGlobe from './WireframeGlobe';
+import ThemeToggle from '../../ThemeToggle';
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -26,7 +27,6 @@ const HeroSection = () => {
   };
 
   useGSAP(() => {
-    // Basic GSAP timeline for text reveals
     const tl = gsap.timeline();
     tl.from('.badge-pill', { opacity: 0, y: -20, duration: 0.5, ease: 'power2.out' })
       .from('.hero-headline span', { opacity: 0, y: 30, duration: 0.8, stagger: 0.2, ease: 'power3.out' }, '-=0.2')
@@ -34,7 +34,6 @@ const HeroSection = () => {
       .from('.hero-cta', { opacity: 0, y: 20, duration: 0.5, stagger: 0.1 }, '-=0.2')
       .from('.hero-input-bar', { opacity: 0, y: 20, duration: 0.6, ease: 'back.out(1.7)' }, '-=0.3');
 
-    // Parallax effect for 3D background on scroll
     gsap.to(canvasContainer.current, {
       yPercent: -20,
       ease: "none",
@@ -45,11 +44,16 @@ const HeroSection = () => {
         scrub: true
       }
     });
-
   }, { scope: container });
 
   return (
     <section ref={container} className="relative w-full h-[100vh] flex flex-col items-center justify-center overflow-hidden">
+      
+      {/* Theme Toggle - top right corner */}
+      <div className="absolute top-6 right-6 z-20">
+        <ThemeToggle />
+      </div>
+
       {/* 3D Background */}
       <div ref={canvasContainer} className="absolute inset-0 z-0">
         <Canvas gl={{ antialias: true, alpha: true }} camera={{ position: [0, 0, 5], fov: 75 }}>
@@ -57,15 +61,12 @@ const HeroSection = () => {
             <Stars radius={100} depth={50} count={6000} factor={4} fade speed={1} />
             <ParticleNetwork />
             <WireframeGlobe />
-            {/* Subtle perspective grid plane fading into distance */}
             <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -3, 0]}>
               <planeGeometry args={[100, 100, 40, 40]} />
               <meshBasicMaterial color="#00F5FF" wireframe transparent opacity={0.05} />
             </mesh>
           </Suspense>
         </Canvas>
-        
-        {/* Gradient overlay to fade bottom into next section */}
         <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-[#050810] to-transparent pointer-events-none" />
       </div>
 
@@ -125,7 +126,6 @@ const HeroSection = () => {
             Analyze →
           </button>
         </form>
-        
       </div>
       
       {/* Scroll indicator */}

--- a/client/src/components/ThemeToggle.jsx
+++ b/client/src/components/ThemeToggle.jsx
@@ -1,0 +1,23 @@
+import { useTheme } from "../context/ThemeContext";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      style={{
+        cursor: "pointer",
+        padding: "8px 16px",
+        borderRadius: "8px",
+        border: "1px solid #00ffcc",
+        background: "transparent",
+        color: "#00ffcc",
+        fontSize: "14px",
+        filter: theme === "light" ? "invert(1) hue-rotate(180deg)" : "none",
+      }}
+    >
+      {theme === "dark" ? "☀️ Light Mode" : "🌙 Dark Mode"}
+    </button>
+  );
+}

--- a/client/src/context/ThemeContext.jsx
+++ b/client/src/context/ThemeContext.jsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useState, useEffect } from "react";
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem("theme") || "dark"
+  );
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => prev === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,1 +1,11 @@
 @import "tailwindcss";
+
+[data-theme="light"] {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+[data-theme="light"] img,
+[data-theme="light"] video,
+[data-theme="light"] canvas {
+  filter: invert(1) hue-rotate(180deg);
+}


### PR DESCRIPTION
## Why
Adds dark/light mode toggle as requested in #1. Some users prefer 
a light theme for readability.

## How
- Added ThemeContext with localStorage persistence
- Added ThemeToggle button component
- Wrapped app with ThemeProvider in App.jsx
- CSS filter approach for full-page theme switching

## Screenshots
<img width="1470" height="956" alt="Screenshot 2026-03-22 at 2 59 01 PM" src="https://github.com/user-attachments/assets/ad7c1746-85dc-4f6b-8cff-29797c28f113" />
<img width="1470" height="956" alt="Screenshot 2026-03-22 at 2 59 11 PM" src="https://github.com/user-attachments/assets/7a23a586-cd67-4277-9b0a-a2ac266e3334" />


Closes #1