### PR TITLE
Addition: small copy URL button inside RepoIdentityCard

### DIFF
--- a/client/src/components/dashboard/RepoIdentityCard.jsx
+++ b/client/src/components/dashboard/RepoIdentityCard.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import CountUp from 'react-countup';
+import { Copy } from 'lucide-react';
 const CountUpComponent = CountUp.default || CountUp;
 
 import { GlassCard } from './shared/Components';
@@ -29,6 +30,8 @@ const StatChip = ({ icon: Icon, value, label, color }) => (
 );
 
 const RepoIdentityCard = ({ data, loading, error, repoUrl }) => {
+    const [toastMessage, setToastMessage] = React.useState('');
+
     if (loading) {
         return <SkeletonCard height="160px" />;
     }
@@ -65,6 +68,17 @@ const RepoIdentityCard = ({ data, loading, error, repoUrl }) => {
                         >
                             <Github size={14} /> View on GitHub ↗
                         </a>
+                        <button
+                            onClick={() => {
+                                navigator.clipboard.writeText(repoUrl);
+                                setToastMessage('URL copied!');
+                                setTimeout(() => setToastMessage(''), 2000);
+                            }}
+                            title="Copy URL"
+                            className="flex items-center gap-2 cursor-pointer hover:text-emerald-400 transition-colors"
+                        >
+                            <Copy size={14} /> Copy Repository URL
+                        </button>
                     </div>
                 </motion.div>
 
@@ -95,6 +109,13 @@ const RepoIdentityCard = ({ data, loading, error, repoUrl }) => {
                         color="border-amber-400" 
                     />
                 </div>
+                
+                {/* Toast confirming copied URL */}
+                {toastMessage && (
+                    <div className="fixed top-5 right-5 bg-black/80 text-white px-4 py-2 rounded shadow-lg animate-slide-in z-50">
+                        {toastMessage}
+                    </div>
+                )}
             </div>
         </GlassCard>
     );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -9,3 +9,12 @@
 [data-theme="light"] canvas {
   filter: invert(1) hue-rotate(180deg);
 }
+
+@keyframes slide-in {
+    0% { transform: translateX(100%); opacity: 0; }
+    100% { transform: translateX(0); opacity: 1; }
+}
+
+.animate-slide-in {
+    animation: slide-in 0.3s ease-out forwards;
+}


### PR DESCRIPTION
# feat: Add "Copy Repository URL" button with confirmation toast in RepoIdentityCard

## Summary
This PR implements and closes #15. It adds a **small "Copy Repository URL" button** to the `RepoIdentityCard` component. Users can now copy the repository URL to their clipboard with a single click. A **floating toast notification** confirms the action, improving the UX and giving immediate feedback.

>Before clicking:
<img width="1543" height="427" alt="image" src="https://github.com/user-attachments/assets/1be702a7-2112-4e5a-abe9-4fedd9a2d621" />

> After clicking:
<img width="1542" height="428" alt="image" src="https://github.com/user-attachments/assets/c1b33415-10bb-40d6-b5cb-789278b39db9" />

---

## Changes Made
1. **Added Copy Button**
   - Imported the `Copy` icon from `lucide-react`.
   - Placed the button next to the "View on GitHub" link.
   - Clicking the button copies `repoUrl` to the clipboard.

2. **Added Toast Notification**
   - Shows **“URL copied!”** in the top-right corner of the card.
   - Toast automatically disappears after 2 seconds.
   - Uses a simple animation (`slide-in`).

3. **Styling Updates**
   - Button uses `hover:text-emerald-400` for visual feedback.
   - Added `animate-slide-in` keyframes to `index.css`.

---

## Why This is Useful
- Enhances user experience by making it easy to copy repo URLs.
- Provides **immediate visual feedback** to confirm the action.
- Follows the existing design and animation patterns of the app.

---
**Notes**
This is my first open-source contribution, I would greatly appreciate feedback if I missed anything! 